### PR TITLE
update CMakeLists.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   - Matplot++: A C++ Graphics Library for Data Visualization
   - Julia: A fresh approach to technical computing
   
-- It is tested on my macOS with Julia v1.5.1
+- It is tested on my macOS/Ubuntu(18.04) with Julia v1.5.1
 
 # Prerequisite
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 - install `gnuplot` via e.g. `brew install ...` or `apt-get install ...` etc..
   - See [this instruction](https://github.com/alandefreitas/matplotplusplus#build-from-source) to learn more.
+- Linux users should update your gcc >= 8
+  - See [this instruction](https://github.com/alandefreitas/matplotplusplus#build-from-source)
 
 ## Install this repository
 

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -3,6 +3,7 @@ project(CppHello)
 cmake_minimum_required(VERSION 3.14)
 set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 find_package(JlCxx)
 get_target_property(JlCxx_location JlCxx::cxxwrap_julia LOCATION)


### PR DESCRIPTION
This PR updates CMakeLists.txt to enable us to build matplotplusplus on ubuntu machine.

Our conventional file gets the following result

```
[ 97%] Linking CXX shared library lib/libmplxx.so
/usr/bin/ld: matplotplusplus/source/matplot/libmatplot.a(axes_type.cpp.o): relocation R_X86_64_PC32 against symbol `_ZN7matplot9axes_type17calculate_marginsEv' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
collect2: error: ld returned 1 exit status
CMakeFiles/mplxx.dir/build.make:106: recipe for target 'lib/libmplxx.so' failed
make[3]: *** [lib/libmplxx.so] Error 1
make[3]: Leaving directory '/home/terasaki/work/MatplotWrap.jl/deps/build'
CMakeFiles/Makefile2:73: recipe for target 'CMakeFiles/mplxx.dir/all' failed
make[2]: *** [CMakeFiles/mplxx.dir/all] Error 2
make[2]: Leaving directory '/home/terasaki/work/MatplotWrap.jl/deps/build'
Makefile:129: recipe for target 'all' failed
make[1]: *** [all] Error 2
make[1]: Leaving directory '/home/terasaki/work/MatplotWrap.jl/deps/build'
Makefile:26: recipe for target 'build' failed
make: *** [build] Error 2
```

this PR should solve this error